### PR TITLE
Fixed bug causing the player sprite to always be moving

### DIFF
--- a/src/main/java/entities/Player.java
+++ b/src/main/java/entities/Player.java
@@ -10,6 +10,7 @@ import util.Sprite;
  */
 public class Player extends Entity {
 
+    private static final int STATIONARY_FRAME = 3;
     private static Sprite SPRITE = new Sprite("mario.png", 8, new Vec2d(11, 35));
 
     private static final double RUN_SPEED  = 256; // px/s
@@ -91,8 +92,9 @@ public class Player extends Entity {
      */
     public void update(double dt) {
         // Update the player sprite
-        sprite.update(dt);
-
+        if(isMoving()) {
+            sprite.update(dt);
+        }
         // Walk
         speed.x = 0;
         if (keyboard.keyPressed(leftKey))  { speed.x -= RUN_SPEED; }
@@ -154,5 +156,19 @@ public class Player extends Entity {
 
     public void draw() {
         sprite.draw(position, side, 1);
+    }
+
+    /**
+     * Checks if any of the movement keys are currently pressed to determine if the player is moving;
+     * @return A boolean that is true if the player is moving, and false otherwise;
+     */
+    public boolean isMoving() {
+        if (keyboard.keyPressed(leftKey) || keyboard.keyPressed(rightKey)){
+            return true;
+        }
+        else {
+            sprite.setCurrentFrame(STATIONARY_FRAME);
+            return false;
+        }
     }
 }

--- a/src/main/java/util/Sprite.java
+++ b/src/main/java/util/Sprite.java
@@ -11,12 +11,39 @@ public class Sprite {
 
     private static GraphicsContext gc = GameCanvasManager.getInstance().getContext();
 
+    /**
+     * Image of the sprite.
+     */
     private Image image;
+
+    /**
+     * The amount of frames the sprite consists of.
+     */
     private int frames;
+
+    /**
+     * The current frame to be displayed.
+     */
     private int currentFrame;
+
+    /**
+     * The frameSpeed at which the sprite should be displayed in frames per second.
+     */
     private int frameSpeed; // Frames / second
+
+    /**
+     * A Vec2d containing the x and y coordinates to be used as the center of the sprite.
+     */
     private Vec2d offset;
+
+    /**
+     * The with and height of the sprite in pixels.
+     */
     private int width, height;
+
+    /**
+     * A double representing a timeline from frame 0 to the last frame. Is used to determine currentFrame.
+     */
     private double framePart;
 
     public Sprite(String uri) {
@@ -138,4 +165,12 @@ public class Sprite {
 
     public int getWidth() { return width; }
     public int getHeight() { return height; }
+
+    /**
+     * Sets the frame of the sprite to be currently displayed, starting at 0.
+     * @param currentFrame
+     */
+    public void setCurrentFrame(int currentFrame) {
+        this.currentFrame = currentFrame;
+    }
 }


### PR DESCRIPTION
### Changed the Player and Sprite class to fix the bug that caused the player sprite to be animated while standing still.
- Added constant field STATIONARY_FRAME to indicate which frame of the sprite is to be displayed when the player sprite is not moving
- Added a isMoving method to Player
- Added a setCurrentFrame method to Sprite
- Added JavaDoc
